### PR TITLE
#166995070 Build the get all trips endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build-babel": "babel ./server --out-dir ./build/server",
     "build": "npm run clean && npm run build-babel",
     "start": "cross-env NODE_ENV=production npm run build && node ./build/server/index.js",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "migration_prod": "cross-env NODE_ENV=production babel-node ./server/model/migration.js --env"
   },
   "repository": {
     "type": "git",

--- a/server/controller/trips.js
+++ b/server/controller/trips.js
@@ -33,4 +33,27 @@ export default class Trips {
     }
     errorHandler.validationError(res, result);
   }
+
+
+  /**
+   * @async
+   * @method - This method retrieves all trips
+   * @param {Object} req - client request Object
+   * @param {Object} res - Server response Object
+   * @returns {JSON} - containing the status message and an array of all trips
+   */
+  static async getAllTrips(req, res) {
+    if ((req.query.page == undefined || req.query.page === 0) && req.query.quantity == undefined) {
+      req.query.page = 1;
+      req.query.quantity = 5;
+    }
+    const result = Joi.validate(req.query, schema.getAllTripsSchema, { convert: true });
+    if (result.error === null) {
+      const { page, quantity } = req.query;
+      const offset = (page - 1) * quantity;
+      const dbOperationResult = await helper.wrapDbOperationInTryCatchBlock(res, queries.getAllTrips, [quantity, offset]);
+      return res.status(200).json(response.success(`All Trips. Page ${page}`, dbOperationResult.rows));
+    }
+    errorHandler.validationError(res, result);
+  }
 }

--- a/server/helper/schema.js
+++ b/server/helper/schema.js
@@ -48,4 +48,15 @@ export default class Schemas {
       status: Joi.string().trim().valid('active', 'cancelled'),
     });
   }
+
+  /**
+   * returns schema for validating user sign in data
+   * @returns {Object} schema for creating an object
+   */
+  static get getAllTripsSchema() {
+    return Joi.object({
+      page: Joi.number().integer(),
+      quantity: Joi.number().integer(),
+    });
+  }
 }

--- a/server/middleware/sanitizer.js
+++ b/server/middleware/sanitizer.js
@@ -47,4 +47,17 @@ export default class Sanitizer {
       check('status').trim(),
     ];
   }
+
+  /**
+   * @param {object} req client request Object
+   * @param {object} res server response object
+   * @param {object} next control structure to continue processing
+   * @returns {JSON}
+   */
+  static sanitizeTripQueries() {
+    return [
+      check('page').isInt(),
+      check('quantity').isInt(),
+    ];
+  }
 }

--- a/server/model/queries.js
+++ b/server/model/queries.js
@@ -15,4 +15,8 @@ export default class Queries {
     return 'SELECT * FROM trips WHERE busid = $1 AND tripdate = $2';
   }
 
+  static get getAllTrips() {
+    return 'SELECT * FROM trips LIMIT  $1 OFFSET $2';
+  }
+
 }

--- a/server/routes/v1/routes.js
+++ b/server/routes/v1/routes.js
@@ -4,13 +4,12 @@ import signInController from '../../controller/signIn';
 import tripController from '../../controller/trips';
 import sanitizer from '../../middleware/sanitizer';
 import Auth from '../../middleware/auth';
-import response from '../../helper/responseSchema';
 
 const router = express.Router();
 
 router.post('/auth/signup', sanitizer.sanitizeUserBioData(), createUserController.signUp);
 router.post('/auth/signin', sanitizer.sanitizeUserSignInData(), signInController.signIn);
 router.post('/trips', sanitizer.sanitizeCreateTripData(), Auth.auth, tripController.createTrip);
-
+router.get('/trips', sanitizer.sanitizeTripQueries(), Auth.auth, tripController.getAllTrips);
 
 export default router;

--- a/server/tests/v1/trips.js
+++ b/server/tests/v1/trips.js
@@ -5,89 +5,111 @@ import app from '../../index';
 const { expect } = chai;
 chai.use(chaiHttp);
 
-describe('Testing the create trip Endpoint', () => {
-  it('should create a new trip successfully', async () => {
-    const res = await chai.request(app).post('/api/v1/trips').set('x-auth-token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJmaXJzdG5hbWUiOiJtYWNobyIsImlzYWRtaW4iOnRydWUsImVtYWlsIjoibGlub0BnbS5jb20iLCJpYXQiOjE1NjE3MDUwMjh9.-KMTYqYKJTTIkm_Xo67KINlK8Q6ZMQItENkfskyWX8E').type('form')
-      .send({
-        busid: 987786,
-        origin: 'togo',
-        tripdate: '2019-07-25',
-        destination: 'ghana',
-        fare: '25000',
-        status: 'active',
-      });
-    expect(res).to.have.status(201);
-    expect(res.body).to.have.property('status');
-    expect(res.body).to.have.property('data');
+describe('Testing the create trips Endpoint', () => {
+  describe('Testing the create trip Endpoint', () => {
+    it('should create a new trip successfully', async () => {
+      const res = await chai.request(app).post('/api/v1/trips').set('x-auth-token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJmaXJzdG5hbWUiOiJtYWNobyIsImlzYWRtaW4iOnRydWUsImVtYWlsIjoibGlub0BnbS5jb20iLCJpYXQiOjE1NjE3MDUwMjh9.-KMTYqYKJTTIkm_Xo67KINlK8Q6ZMQItENkfskyWX8E').type('form')
+        .send({
+          busid: 987786,
+          origin: 'togo',
+          tripdate: '2019-07-25',
+          destination: 'ghana',
+          fare: '25000',
+          status: 'active',
+        });
+      expect(res).to.have.status(201);
+      expect(res.body).to.have.property('status');
+      expect(res.body).to.have.property('data');
+    });
+
+    it('should return a validation error', async () => {
+      const res = await chai.request(app).post('/api/v1/trips').set('x-auth-token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJmaXJzdG5hbWUiOiJtYWNobyIsImlzYWRtaW4iOnRydWUsImVtYWlsIjoibGlub0BnbS5jb20iLCJpYXQiOjE1NjE3MDUwMjh9.-KMTYqYKJTTIkm_Xo67KINlK8Q6ZMQItENkfskyWX8E').type('form')
+        .send({
+          busid: 9886,
+          origin: 'togo',
+          tripdate: '2019-07-25',
+          destination: 'ghana',
+          fare: '25000',
+          status: 'bad',
+        });
+      expect(res).to.have.status(400);
+      expect(res.body).to.have.property('status');
+    });
+
+    it('should return an already existent trip message', async () => {
+      const res = await chai.request(app).post('/api/v1/trips').set('x-auth-token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJmaXJzdG5hbWUiOiJtYWNobyIsImlzYWRtaW4iOnRydWUsImVtYWlsIjoibGlub0BnbS5jb20iLCJpYXQiOjE1NjE3MDUwMjh9.-KMTYqYKJTTIkm_Xo67KINlK8Q6ZMQItENkfskyWX8E').type('form')
+        .send({
+          busid: 987786,
+          origin: 'togo',
+          tripdate: '2019-07-25',
+          destination: 'ghana',
+          fare: '25000',
+          status: 'active',
+        });
+      expect(res).to.have.status(409);
+      expect(res.body).to.have.property('status');
+    });
+
+    it('should return a 401 error no token', async () => {
+      const res = await chai.request(app).post('/api/v1/trips').set('x-auth-token', '').type('form')
+        .send({
+          busid: 987789086,
+          origin: 'togo',
+          tripdate: '2019-07-25',
+          destination: 'ghana',
+          fare: '25000',
+          status: 'active',
+        });
+      expect(res).to.have.status(401);
+      expect(res.body).to.have.property('status');
+    });
+
+    it('should return a 401 error unauthorized user', async () => {
+      const res = await chai.request(app).post('/api/v1/trips').set('x-auth-token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJlbWFpbCI6InN0YW5AZ20uY29tIiwiZmlyc3RuYW1lIjoic3RhbiIsImlzYWRtaW4iOmZhbHNlLCJpYXQiOjE1NjE3NjYxMTF9.aK-kWxpW9gDWGbDyo26M11QTbic1op4x8OKQX_OZzDQ').type('form')
+        .send({
+          busid: 987789086,
+          origin: 'togo',
+          tripdate: '2019-07-25',
+          destination: 'ghana',
+          fare: '25000',
+          status: 'active',
+        });
+      expect(res).to.have.status(401);
+      expect(res.body).to.have.property('status');
+    });
+
+    it('should return a 400 error invalid token', async () => {
+      const res = await chai.request(app).post('/api/v1/trips').set('x-auth-token', 'eyJhbGciOiJIUiouizI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJlbWFpbCI6InN0YW5AZ20uY29tIiwiZmlyc3RuYW1lIjoic3RhbiIsImlzYWRtaW4iOmZhbHNlLCJpYXQiOjE1NjE3NjYxMTF9.aK-kWxpW9gDWGbDyo26M11QTbic1op4x8OKQX_OZzDQ').type('form')
+        .send({
+          busid: 987789086,
+          origin: 'togo',
+          tripdate: '2019-07-25',
+          destination: 'ghana',
+          fare: '25000',
+          status: 'active',
+        });
+      expect(res).to.have.status(400);
+      expect(res.body).to.have.property('status');
+    });
   });
 
-  it('should return a validation error', async () => {
-    const res = await chai.request(app).post('/api/v1/trips').set('x-auth-token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJmaXJzdG5hbWUiOiJtYWNobyIsImlzYWRtaW4iOnRydWUsImVtYWlsIjoibGlub0BnbS5jb20iLCJpYXQiOjE1NjE3MDUwMjh9.-KMTYqYKJTTIkm_Xo67KINlK8Q6ZMQItENkfskyWX8E').type('form')
-      .send({
-        busid: 9886,
-        origin: 'togo',
-        tripdate: '2019-07-25',
-        destination: 'ghana',
-        fare: '25000',
-        status: 'bad',
-      });
-    expect(res).to.have.status(400);
-    expect(res.body).to.have.property('status');
-  });
+  describe('Testing the get all trips method', () => {
+    it('should retrieve trips successfully', async () => {
+      const res = await chai.request(app).get('/api/v1/trips').set('x-auth-token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJlbWFpbCI6Imxpbm9AZ20uY29tIiwiZmlyc3RuYW1lIjoibWFjaG8iLCJpc2FkbWluIjp0cnVlLCJpYXQiOjE1NjE3OTAwMTZ9.yk9Fa2KD2d2UxoGLmeiXUd_qMt0HyVuiYXnxF9BLGzM');
+      expect(res).to.have.status(200);
+      expect(res.body).to.have.property('status');
+    });
 
-  it('should return an already existent trip message', async () => {
-    const res = await chai.request(app).post('/api/v1/trips').set('x-auth-token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJmaXJzdG5hbWUiOiJtYWNobyIsImlzYWRtaW4iOnRydWUsImVtYWlsIjoibGlub0BnbS5jb20iLCJpYXQiOjE1NjE3MDUwMjh9.-KMTYqYKJTTIkm_Xo67KINlK8Q6ZMQItENkfskyWX8E').type('form')
-      .send({
-        busid: 987786,
-        origin: 'togo',
-        tripdate: '2019-07-25',
-        destination: 'ghana',
-        fare: '25000',
-        status: 'active',
-      });
-    expect(res).to.have.status(409);
-    expect(res.body).to.have.property('status');
-  });
+    it('should retrieve trips successfully by setting a page number and quantity per page', async () => {
+      const res = await chai.request(app).get('/api/v1/trips?page=1&quantity=3').set('x-auth-token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJlbWFpbCI6Imxpbm9AZ20uY29tIiwiZmlyc3RuYW1lIjoibWFjaG8iLCJpc2FkbWluIjp0cnVlLCJpYXQiOjE1NjE3OTAwMTZ9.yk9Fa2KD2d2UxoGLmeiXUd_qMt0HyVuiYXnxF9BLGzM');
+      expect(res).to.have.status(200);
+      expect(res.body).to.have.property('status');
+    });
 
-  it('should return a 401 error no token', async () => {
-    const res = await chai.request(app).post('/api/v1/trips').set('x-auth-token', '').type('form')
-      .send({
-        busid: 987789086,
-        origin: 'togo',
-        tripdate: '2019-07-25',
-        destination: 'ghana',
-        fare: '25000',
-        status: 'active',
-      });
-    expect(res).to.have.status(401);
-    expect(res.body).to.have.property('status');
-  });
-
-  it('should return a 401 error unauthorized user', async () => {
-    const res = await chai.request(app).post('/api/v1/trips').set('x-auth-token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJlbWFpbCI6InN0YW5AZ20uY29tIiwiZmlyc3RuYW1lIjoic3RhbiIsImlzYWRtaW4iOmZhbHNlLCJpYXQiOjE1NjE3NjYxMTF9.aK-kWxpW9gDWGbDyo26M11QTbic1op4x8OKQX_OZzDQ').type('form')
-      .send({
-        busid: 987789086,
-        origin: 'togo',
-        tripdate: '2019-07-25',
-        destination: 'ghana',
-        fare: '25000',
-        status: 'active',
-      });
-    expect(res).to.have.status(401);
-    expect(res.body).to.have.property('status');
-  });
-
-  it('should return a 400 error invalid token', async () => {
-    const res = await chai.request(app).post('/api/v1/trips').set('x-auth-token', 'eyJhbGciOiJIUiouizI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJlbWFpbCI6InN0YW5AZ20uY29tIiwiZmlyc3RuYW1lIjoic3RhbiIsImlzYWRtaW4iOmZhbHNlLCJpYXQiOjE1NjE3NjYxMTF9.aK-kWxpW9gDWGbDyo26M11QTbic1op4x8OKQX_OZzDQ').type('form')
-      .send({
-        busid: 987789086,
-        origin: 'togo',
-        tripdate: '2019-07-25',
-        destination: 'ghana',
-        fare: '25000',
-        status: 'active',
-      });
-    expect(res).to.have.status(400);
-    expect(res.body).to.have.property('status');
+    it('should return a validation error', async () => {
+      const res = await chai.request(app).get('/api/v1/trips?page=cow&quantity=3').set('x-auth-token', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJlbWFpbCI6Imxpbm9AZ20uY29tIiwiZmlyc3RuYW1lIjoibWFjaG8iLCJpc2FkbWluIjp0cnVlLCJpYXQiOjE1NjE3OTAwMTZ9.yk9Fa2KD2d2UxoGLmeiXUd_qMt0HyVuiYXnxF9BLGzM');
+      expect(res).to.have.status(400);
+      expect(res.body).to.have.property('status');
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do?
Builds the get all trips endpoint on the wayfarer api.
## Description of Task to be completed?
Have the below endpoint working.
- GET /api/v1/trips
## How should this be manually tested?
- After cloning the repo cd into it and run 'npm install'
- edit the .sample.env file with your own values and change its name to .env
- run 'npm start'
- using postman sign up as described [here](https://github.com/otaigbe/WayFarer/pull/1) or sign in(if signed up) as described [here](https://github.com/otaigbe/WayFarer/pull/2) 
- input the url endpoint '/api/v1/trips' prepended with your local values form the .env file
- add page and quantity query parameters to the url like this (?page=1&quantity=3)
- select the get method
- click send

## What are the relevant pivotal tracker stories?
#166995070
